### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Environment Setup - Node
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2
         with:
           node-version: 14.x
 


### PR DESCRIPTION
The pipeline was failing with:
Error: Unable to process command '::add-path::/opt/hostedtoolcache/node/14.15.1/x64/bin' successfully.
9
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

It seems that we do not need to hardcode the setup-node action version, as my feature branch got built successfully.