### PR TITLE
[SAN-12328] Remove BackgroundActionButtonHandler registration

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -40,8 +40,6 @@
           <category android:name="android.intent.category.DEFAULT" />
         </intent-filter>
       </activity>
-
-      <receiver android:name="com.adobe.phonegap.push.BackgroundActionButtonHandler"/>
       <receiver android:name="com.adobe.phonegap.push.PushDismissedHandler"/>
 
       <service android:name="com.adobe.phonegap.push.FCMService" />


### PR DESCRIPTION
Remove BackgroundActionButtonHandler registration as it's already declared in https://github.com/sanvello/cordova-plugin-android-unified-firebase-messaging-event-handler/pull/2/commits/65d6353568d14ae334fa8e0482de3b327c61afcb