### PR TITLE
Added mutability flag on PendingIntents

### DIFF
--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -471,7 +471,7 @@ public class FCMService extends FirebaseMessagingService {
     SecureRandom random = new SecureRandom();
     int requestCode = random.nextInt();
     PendingIntent contentIntent = PendingIntent.getActivity(this, requestCode, notificationIntent,
-        PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent.FLAG_UPDATE_CURRENT|PendingIntent.FLAG_IMMUTABLE);
 
     Intent dismissedNotificationIntent = new Intent(this, PushDismissedHandler.class);
     dismissedNotificationIntent.putExtra(PUSH_BUNDLE, extras);
@@ -481,7 +481,7 @@ public class FCMService extends FirebaseMessagingService {
 
     requestCode = random.nextInt();
     PendingIntent deleteIntent = PendingIntent.getBroadcast(this, requestCode, dismissedNotificationIntent,
-        PendingIntent.FLAG_CANCEL_CURRENT);
+        PendingIntent.FLAG_CANCEL_CURRENT|PendingIntent.FLAG_IMMUTABLE);
 
     NotificationCompat.Builder mBuilder = null;
 


### PR DESCRIPTION
This meets requirements for Android 12: https://developer.android.com/reference/android/app/PendingIntent#FLAG_MUTABLE

The https://github.com/phonegap/phonegap-plugin-push **has been archived since 2020**. The maintainers suggest:

"This project is not under active development. Folks who are users of this plugin should switch to using [cordova-plugin-push](https://github.com/havesource/cordova-plugin-push) which is a fork of this project."

Followed what is done in: https://github.com/havesource/cordova-plugin-push/blob/c3fb5b894afe17a05e21be135961f5831bafb1e0/src/android/com/adobe/phonegap/push/FCMService.kt

**We can consider switching the fork if we continue to have issues.**