### PR TITLE
[JOY-14390] Fix: iOS builds failing with gym errors

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -116,7 +116,7 @@
       <!-- keep empty `config` object to prevent `cordova-common` install issues.-->
       <config></config>
       <pods use-frameworks="true">
-        <pod name="Firebase/Messaging" spec="~> 6.34.0" />
+        <pod name="Firebase/Messaging" />
       </pods>
     </podspec>
   </platform>

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -179,19 +179,7 @@
         NSLog(@"Push Plugin VoIP missing or false");
         [[NSNotificationCenter defaultCenter]
          addObserver:self selector:@selector(onTokenRefresh)
-         name:kFIRInstanceIDTokenRefreshNotification object:nil];
-
-        [[NSNotificationCenter defaultCenter]
-         addObserver:self selector:@selector(sendDataMessageFailure:)
-         name:FIRMessagingSendErrorNotification object:nil];
-
-        [[NSNotificationCenter defaultCenter]
-         addObserver:self selector:@selector(sendDataMessageSuccess:)
-         name:FIRMessagingSendSuccessNotification object:nil];
-
-        [[NSNotificationCenter defaultCenter]
-         addObserver:self selector:@selector(didDeleteMessagesOnServer)
-         name:FIRMessagingMessagesDeletedNotification object:nil];
+         name:FIRMessagingRegistrationTokenRefreshedNotification object:nil];
 
         [self.commandDelegate runInBackground:^ {
             NSLog(@"Push Plugin register called");


### PR DESCRIPTION
**NB:** The upstream of this fork is misleading as it points to https://github.com/phonegap/phonegap-plugin-push but was updated [here](https://github.com/sanvello/pacifica/pull/4877) using https://github.com/havesource/cordova-plugin-push

The QA iOS pipeline started to fail on May 9th. This was e result of the `Protobuf` pod's latest release as it's not set to a fixed version for `Firebase/Messaging` 6.34.0: https://github.com/firebase/firebase-ios-sdk/blob/CocoaPods-6.34.0/FirebaseMessaging.podspec#L63

Finding the right version for all the Firebase pods was way harder than expected as `FirebaseCore` is a dependency of both `Messaging` and `Crashlytics` so it should match both. My inial approach was to use the version of `Firebase/Messaging` suggested by the upcoming release of the Push Plugin we're no referencing: https://github.com/havesource/cordova-plugin-push/blob/4.0.0-dev.0/plugin.xml#L95. But that required changes in the iOS native code that seem to break the APNS token registration so no permissions prompt was shown on iOS and no notifications were delivered.

**The PR removes the version of `Firebase/Messaging` set by the plugin and lets the `updatePodfile` (that actually becomes `platforms/ios/Podfile` during the platform install process) in `pacifica` dictate that. The rest of the changes fix build errors that are a result of the `Firebase/Messaging` version bump - `7.0.0` - which seems to fire the registration event properly and also doesn't contain the problematic dependency - `Protobuf`.**