### PR TITLE
[JOY-15903] Target Android 13 (API level 33)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -30,6 +30,7 @@
       <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
       <uses-permission android:name="android.permission.WAKE_LOCK"/>
       <uses-permission android:name="android.permission.VIBRATE"/>
+      <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest/application">


### PR DESCRIPTION
This adds `POST_NOTIFICATIONS` permission to meet requirements for Android 13.

We should ideally update our fork with the upstream but this is currently not feasible as the upstream had a major refactor of the native Android side (Java -> Kotlin).